### PR TITLE
fix Circos drawing

### DIFF
--- a/bin/lib.lua
+++ b/bin/lib.lua
@@ -191,7 +191,7 @@ function get_fasta(filename, sep)
   local cur_hdr = nil
   local cur_seqs = {}
   if not file_exists(filename) then
-    error("file " .. filename .. " can not be loaded")
+    error("file " .. filename .. " does not exist")
   end
   for l in io.lines(filename) do
     hdr = l:match(">(.*)")

--- a/bin/prepare_circos_inputs.lua
+++ b/bin/prepare_circos_inputs.lua
@@ -57,6 +57,13 @@ end
 
 has_bin = false
 
+-- gather real lengths of reference chromsomes
+refsizes = {}
+refhdr, refseqs = get_fasta_nosep(ref_dir .. '/' .. ref_name .. '/chromosomes.fasta')
+for k, v in pairs(refseqs) do
+  refsizes[k] = v:len()
+end
+
 -- holds reference chromosomes
 ref_chr = {}
 
@@ -79,9 +86,15 @@ function visitor:visit_feature(fn)
   return 0
 end
 function visitor:visit_region(rn)
+  local endrng = rn:get_range():get_end()
+  if self.is_ref and refsizes[rn:get_seqid()] then
+    endrng = refsizes[rn:get_seqid()]
+  end
+  if tonumber(endrng) == nil then
+   error("non-numeric end range encountered for chromosome " .. rn:get_seqid() .. ": " .. endrng)
+  end
   karyotype_out:write("chr - " .. rn:get_seqid() .. " " .. rn:get_seqid()
-                        .. " " .. rn:get_range():get_start() .. " "
-                        .. rn:get_range():get_end() .. " ")
+                        .. " 1 " .. endrng .. " ")
   if rn:get_seqid() == bin_chr then
     karyotype_out:write("black")
   else

--- a/data/circos/circos.bin.conf
+++ b/data/circos/circos.bin.conf
@@ -59,7 +59,7 @@ layers      = 1
 margin      = 0.02u
 thickness   = 30
 padding     = 2
-stroke_thickness = 1
+stroke_thickness = 0
 </plot>
 
 <plot>
@@ -71,7 +71,7 @@ layers      = 1
 margin      = 0.02u
 thickness   = 30
 padding     = 2
-stroke_thickness = 1
+stroke_thickness = 0
 stroke_color     = grey
 </plot>
 
@@ -84,7 +84,7 @@ layers      = 1
 margin      = 0.02u
 thickness   = 30
 padding     = 2
-stroke_thickness = 1
+stroke_thickness = 0
 stroke_color     = grey
 </plot>
 

--- a/data/circos/circos.bin.debian.conf
+++ b/data/circos/circos.bin.debian.conf
@@ -59,7 +59,7 @@ layers      = 1
 margin      = 0.02u
 thickness   = 30
 padding     = 2
-stroke_thickness = 1
+stroke_thickness = 0
 </plot>
 
 <plot>
@@ -71,7 +71,7 @@ layers      = 1
 margin      = 0.02u
 thickness   = 30
 padding     = 2
-stroke_thickness = 1
+stroke_thickness = 0
 stroke_color     = grey
 </plot>
 
@@ -84,7 +84,7 @@ layers      = 1
 margin      = 0.02u
 thickness   = 30
 padding     = 2
-stroke_thickness = 1
+stroke_thickness = 0
 stroke_color     = grey
 </plot>
 

--- a/data/circos/circos.conf
+++ b/data/circos/circos.conf
@@ -99,7 +99,7 @@ layers      = 1
 margin      = 0.02u
 thickness   = 30
 padding     = 2
-stroke_thickness = 1
+stroke_thickness = 0
 </plot>
 
 <plot>
@@ -111,7 +111,7 @@ layers      = 1
 margin      = 0.02u
 thickness   = 30
 padding     = 2
-stroke_thickness = 1
+stroke_thickness = 0
 stroke_color     = grey
 </plot>
 
@@ -124,7 +124,7 @@ layers      = 1
 margin      = 0.02u
 thickness   = 30
 padding     = 2
-stroke_thickness = 1
+stroke_thickness = 0
 stroke_color     = grey
 </plot>
 

--- a/data/circos/circos.debian.conf
+++ b/data/circos/circos.debian.conf
@@ -99,7 +99,7 @@ layers      = 1
 margin      = 0.02u
 thickness   = 30
 padding     = 2
-stroke_thickness = 1
+stroke_thickness = 0
 </plot>
 
 <plot>
@@ -111,7 +111,7 @@ layers      = 1
 margin      = 0.02u
 thickness   = 30
 padding     = 2
-stroke_thickness = 1
+stroke_thickness = 0
 stroke_color     = grey
 </plot>
 
@@ -124,7 +124,7 @@ layers      = 1
 margin      = 0.02u
 thickness   = 30
 padding     = 2
-stroke_thickness = 1
+stroke_thickness = 0
 stroke_color     = grey
 </plot>
 


### PR DESCRIPTION
This PR fixes a bug where Circos would not draw some links because the reference chromosome coordinate region was too short in the karyotype definition. The karyotype boundaries were determined from the range of annotated genes while the linked regions were determined from purely sequence-based matches, so for sparsely annotated chromosomes the sequence matches could be outside the range covered by annotated genes, causing Circos to drop the link.
I'm also sneaking in a few cosmetic changes.