### PR TITLE
use new version of libgsl package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get install build-essential hmmer lua5.1 ncbi-blast+ blast2 snap \
                     unzip cpanminus mummer infernal exonerate mafft fasttree \
                     circos libsvg-perl libgd-svg-perl python-setuptools \
                     libc6-i386 lib32stdc++6 lib32gcc1 netcat genometools \
-                    last-align libboost-iostreams-dev libgsl0ldbl libgsl0-dev \
+                    last-align libboost-iostreams-dev libgsl2 libgsl-dev \
                     libcolamd2.9.1 liblpsolve55-dev libstdc++6 aragorn tantan \
                     libstorable-perl libbio-perl-perl libsqlite3-dev \
                      --yes --force-yes


### PR DESCRIPTION
This PR replaces the libgsl dependency in the Dockerfile with the most recent version.