### PR TITLE
EMBL export improvements

### DIFF
--- a/bin/gff3_to_embl.lua
+++ b/bin/gff3_to_embl.lua
@@ -323,8 +323,13 @@ function embl_vis:visit_feature(fn)
           end)
         if fn:get_type() == "pseudogene" then
           io.write("FT                   /pseudo\n")
+          --io.write("FT                   /pseudogene=\"unknown\"\n")
         end
-        format_embl_attrib(pp, "product", "product",
+        local target_product = "product"
+        if fn:get_type() == "pseudogene" and embl_compliant then
+          target_product = "note"
+        end
+        format_embl_attrib(pp, "product", target_product,
           function (s)
             local pr_a = gff3_extract_structure(s)
             local gprod = nil


### PR DESCRIPTION
This PR introduces the following new features:
 - The new `-s` option to `gff3_to_embl.lua` which makes the converter emit contig features in the input as `source` qualifiers in the EMBL output -- this allows to split concatenated bins without spacers for manual submission
 - Product descriptions in pseudogenes are now moved to `note` qualifiers to comply with ENA requirements.