### PR TITLE
Robustness improvements

### DIFF
--- a/bin/cufflinks_to_hints.lua
+++ b/bin/cufflinks_to_hints.lua
@@ -2,7 +2,7 @@
 
 --[[
   Author: Sascha Steinbiss <ss34@sanger.ac.uk>
-  Copyright (c) 2015 Genome Research Ltd
+  Copyright (c) 2015-2016 Genome Research Ltd
 
   Permission to use, copy, modify, and distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -43,19 +43,21 @@ function print_gff(seqid, type, start, stop, strand, name)
            .. "\t.\tgrp=" .. name .. ";src=" .. options.hint_type)
 end
 
-local feats = {}
 
+feats = {}
 -- parse from GTF input
-for l in io.lines() do
-  local larr = split(l:gsub('"'," "), "%s")
-  if not feats[larr[15]] then
-    feats[larr[15]] = {}
+for f in gtf_lines(io.stdin) do
+  if f.type == 'exon' and f.attribs.transcript_id then
+    if not feats[f.attribs.transcript_id] then
+      feats[f.attribs.transcript_id] = {}
+    end
+    table.insert(feats[f.attribs.transcript_id], {seq = f.seqid,
+                                                  f.attribs.gene_id,
+                                                 tid = f.attribs.transcript_id,
+                                                 start = f.from,
+                                                 stop = f.to,
+                                                 strand=f.strand})
   end
-  table.insert(feats[larr[15]], {seq = larr[1], name = larr[11],
-    tid = larr[15],
-                                 start = tonumber(larr[4]),
-                                 stop = tonumber(larr[5]),
-                                 strand=larr[7]})
 end
 
 -- create hints file

--- a/bin/gff3_to_embl.lua
+++ b/bin/gff3_to_embl.lua
@@ -270,7 +270,9 @@ function output_embl_header(fn)
     embl_vis.last_seqid = fn:get_seqid()
     io.output(fn:get_seqid()..".embl", "w+")
     if embl_compliant then
-      io.write("ID   XXX; XXX; linear; XXX; XXX; XXX; XXX.\n")
+      io.write("ID   XXX; XXX; linear; "
+                 .. "genomic DNA; STD; UNC; "
+                 .. tostring(collect_vis.lengths[fn:get_seqid()]) .." BP.\n")
       io.write("XX   \n")
       io.write("AC   XXX;\n")
       io.write("XX   \n")

--- a/bin/gff3_to_embl.lua
+++ b/bin/gff3_to_embl.lua
@@ -433,16 +433,16 @@ function embl_vis:visit_feature(fn)
           cdnaseq = node:extract_sequence("CDS", true, region_mapping)
           protseq = node:extract_and_translate_sequence("CDS", true,
                                                         region_mapping)
-          local startcodon = cdnaseq:sub(start_phase + 1, start_phase + 3):lower()
-          if embl_compliant and startcodon:match('^[tc]tg$') then
+          --local startcodon = cdnaseq:sub(start_phase + 1, start_phase + 3):lower()
+          --if embl_compliant and startcodon:match('^[tc]tg$') then
             -- The ENA expects non-M start codons (e.g. Ls) to be represented as
             -- Ms in the literal translation (according to their validator
             -- output). Emulating this behaviour here, diverging from the actual
             -- translation table.
-            if protseq:sub(1,1):upper() == 'L' then
-              protseq = 'M' .. protseq:sub(2)
-            end
-          end
+          --  if protseq:sub(1,1):upper() == 'L' then
+          --    protseq = 'M' .. protseq:sub(2)
+          --  end
+          --end
           if embl_compliant and cdnaseq:len() % 3 > 0 then
             -- The ENA expects translations for DNA sequences with a length
             -- which is not a multiple of three in a different way from the one

--- a/bin/lib.lua
+++ b/bin/lib.lua
@@ -219,6 +219,37 @@ function get_fasta_nosep(filename)
   return get_fasta(filename, "")
 end
 
+function gtf_lines(in_io)
+  -- returns, for each GTF line, a table with the 8 first column values as
+  -- strings/numbers; attributes are given in a sub-table called 'attribs'
+  assert(in_io)
+  return function()
+    local line = in_io:read()
+    while (line and line:sub(1,1) == '#') do
+      line = in_io:read()
+    end
+    if line then
+      local larr = split(line, "\t")
+      if #larr ~= 9 then
+        error('could not parse 9 columns from input line "' .. line .. '"')
+      end
+      local seqid, source, type, from, to, score, strand, phase,
+            attr = unpack(larr)
+      local feat = {seqid = seqid, source = source, type = type,
+                    from = tonumber(from), to = tonumber(to),
+                    score = tonumber(score), strand = strand, phase = phase}
+      local attr_table = {}
+      attr:gsub('([%a_]+) "([^"]+)";', function(k,v)
+        attr_table[k] = v
+      end)
+      feat.attribs = attr_table
+      return feat
+    else
+      return nil
+    end
+  end
+end
+
 function visitor_stream_new(instream, vis)
   -- make simple visitor stream, just applies given visitor to every node
   local visitor_stream = gt.custom_stream_new_unsorted()

--- a/bin/pseudo_merge_with_genes.lua
+++ b/bin/pseudo_merge_with_genes.lua
@@ -154,12 +154,16 @@ function frame_agreement(f1, f1type, f2, f2type)
     end
     if (c1 % 3) ~= (c2 % 3) then
       if options.debug then
-        io.stderr:write("different frames: " .. tostring(f2:get_attribute("ID")) .. " " .. c1 % 3 .. " vs " .. c2 % 3 .. " (" .. tostring(f2:get_strand()) ..")\n")
+        io.stderr:write("different frames: " ..
+                        tostring(f2:get_attribute("ID")) ..
+                        " " .. c1 % 3 .. " vs " .. c2 % 3 ..
+                        " (" .. tostring(f2:get_strand()) ..")\n")
       end
       return false
     else
       if options.debug then
-        io.stderr:write("same frame " .. tostring(f2:get_attribute("ID")) .. "\n")
+        io.stderr:write("same frame " .. tostring(f2:get_attribute("ID")) ..
+                        "\n")
       end
       return true
     end


### PR DESCRIPTION
This PR introduces the following changes:

 - Disable start codon hack in EMBL export. This seems to create more problems since ENA are regenerating the translation from the gene models and this would mask errors.
 - Add new GTF parser. This now properly builds a Lua table for each feature instead of relying on a specific Cufflinks output format (which might be subject to change).
 - Add extra header fields in EMBL output. This allows Biopython to process the ENA optimized EMBL format, e.g. for downstream processing.