### PR TITLE
ignore nonzero exit codes from speck

### DIFF
--- a/annot.nf
+++ b/annot.nf
@@ -1418,6 +1418,8 @@ if (params.make_embl) {
 
 specfile = file(params.SPECFILE)
 process make_report {
+    validExitStatus 0,1,2
+
     input:
     set file('pseudo.fasta.gz'), file('scaf.fasta.gz') from report_inseq
     set file('pseudo.gff3'), file('scaf.gff3') from report_gff3


### PR DESCRIPTION
After merging https://github.com/genometools/genometools/issues/811 failures
during reporting will result in >0 error codes, which we would like to ignore
here -- we need to finish the pipeline even if there are issues.