### PR TITLE
new travis build that pulls rather than builds the docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ services:
    - docker
 
 before_install:
-  - docker build -t companion_image .
+  - # docker build -t companion_image .
+  - docker pull trstickland/companion
+  - docker tag trstickland/companion companion_image
   - docker run -dit -v $TRAVIS_BUILD_DIR:/tmp/companion --name companion_container companion_image /bin/bash
   - sleep 5
   - docker container ls
@@ -22,6 +24,7 @@ cache:
 env:
   global:
     - ROOTDIR="$TRAVIS_BUILD_DIR"
+    
 script:
   - docker exec companion_container /bin/bash -c 'cd /tmp/companion/test/testsuite; ./testsuite.rb -threads 2'
   - travis_wait docker exec companion_container /bin/bash -c 'cd /tmp/companion; ./nextflow -c loc_travis.config -c params_default.config run annot.nf --do_circos=false'


### PR DESCRIPTION
travis build failing to build docker image, OrthoMCL download times out though build OK locally; so switch to pulling docker image from dockerhub (and hope the build there doesn't break...(